### PR TITLE
Fix off by one when finding the next free id and fix static and lambda methods getting an incorrect name

### DIFF
--- a/jam/src/main/java/com/ldtteam/jam/ast/NamedASTBuilder.java
+++ b/jam/src/main/java/com/ldtteam/jam/ast/NamedASTBuilder.java
@@ -15,6 +15,7 @@ import com.ldtteam.jam.spi.ast.named.builder.INamedASTBuilder;
 import com.ldtteam.jam.spi.ast.named.builder.INamedClassBuilder;
 import com.ldtteam.jam.spi.name.INameProvider;
 import com.ldtteam.jam.spi.name.IRemapper;
+import org.objectweb.asm.Opcodes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -190,7 +191,7 @@ public class NamedASTBuilder implements INamedASTBuilder
         final Multimap<MethodData, MethodData> overrides = HashMultimap.create();
         methods.forEach(
           methodData -> {
-              if (methodData.node().name.startsWith("<"))
+              if (methodData.node().name.startsWith("<") || (methodData.node().access & (Opcodes.ACC_STATIC | Opcodes.ACC_PRIVATE)) != 0)
               {
                   return;
               }

--- a/mcpconfig/src/main/java/com/ldtteam/jam/mcpconfig/TSRGNewIdentitySupplier.java
+++ b/mcpconfig/src/main/java/com/ldtteam/jam/mcpconfig/TSRGNewIdentitySupplier.java
@@ -46,7 +46,7 @@ public class TSRGNewIdentitySupplier implements INewIdentitySupplier
             ))
            .mapToInt(Integer::parseInt)
            .max()
-           .orElse(-1);
+           .orElse(-1) + 1;
     }
 
     @Override


### PR DESCRIPTION
When finding the next free id to use the maximum id currently existing is used but instead of incrementing it by 1 it didn't causing the first new id to conflict with the last old id from the previous version.

Static and private methods don't override other methods.